### PR TITLE
build: Addressed CVEs CVE-2020-13956 CVE-2020-17527

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -248,6 +248,22 @@ dependencies {
     compile group: 'com.google.guava', name: 'guava', version: '27.0-jre'
 
     compile group: 'com.google.guava', name: 'guava', version: '28.2-jre'
+    implementation('org.apache.tomcat.embed:tomcat-embed-core:9.0.40') {
+        because 'Apache Tomcat 10.0.0-M1 to 10.0.0-M9, 9.0.0-M1 to 9.0.39 and 8.5.0 to 8.5.59 could re-use an HTTP ' +
+                'request header value from the previous stream received on an HTTP/2 connection for the request associated ' +
+                'with the subsequent stream. While this would most likely lead to an error and the closure of the HTTP/2 connection, ' +
+                'it is possible that information could leak between requests'
+    }
+    implementation('org.apache.tomcat.embed:tomcat-embed-websocket:9.0.40') {
+        because 'Apache Tomcat 10.0.0-M1 to 10.0.0-M9, 9.0.0-M1 to 9.0.39 and 8.5.0 to 8.5.59 could re-use an HTTP ' +
+                'request header value from the previous stream received on an HTTP/2 connection for the request associated ' +
+                'with the subsequent stream. While this would most likely lead to an error and the closure of the HTTP/2 connection, ' +
+                'it is possible that information could leak between requests'
+    }
+    implementation('org.apache.httpcomponents:httpclient:4.5.13') {
+        because 'Apache HttpClient versions prior to version 4.5.13 can misinterpret malformed authority component in ' +
+                'request URIs passed to the library as java.net.URI object and pick the wrong target host for request execution.'
+    }
 
     testCompile group: 'io.rest-assured', name: 'rest-assured', version: '3.3.0'
 

--- a/build.gradle
+++ b/build.gradle
@@ -264,21 +264,6 @@ dependencies {
         because 'Apache HttpClient versions prior to version 4.5.13 can misinterpret malformed authority component in ' +
                 'request URIs passed to the library as java.net.URI object and pick the wrong target host for request execution.'
     }
-    implementation('org.codehaus.groovy:groovy:2.5.14') {
-        because 'Apache Groovy provides extension methods to aid with creating temporary directories. ' +
-                'Prior to this fix, Groovy\'s implementation of those extension methods was using a now superseded ' +
-                'Java JDK method call that is potentially not secure on some operating systems in some contexts'
-    }
-    implementation('org.codehaus.groovy:groovy-json:2.5.14') {
-        because 'Apache Groovy provides extension methods to aid with creating temporary directories. ' +
-                'Prior to this fix, Groovy\'s implementation of those extension methods was using a now superseded ' +
-                'Java JDK method call that is potentially not secure on some operating systems in some contexts.'
-    }
-    implementation('org.codehaus.groovy:groovy-xml:2.5.14') {
-        because 'Apache Groovy provides extension methods to aid with creating temporary directories. ' +
-                'Prior to this fix, Groovy\'s implementation of those extension methods was using a now superseded ' +
-                'Java JDK method call that is potentially not secure on some operating systems in some contexts.'
-    }
 
     testCompile group: 'io.rest-assured', name: 'rest-assured', version: '3.3.0'
 
@@ -325,10 +310,6 @@ dependencies {
     testCompile(group: 'org.yaml', name: 'snakeyaml', version: '1.25') {
         force = true
     }
-
-    testCompile group: 'org.codehaus.groovy', name: 'groovy', version: '2.5.14'
-    testCompile group: 'org.codehaus.groovy', name: 'groovy-xml', version: '2.5.14'
-    testCompile group: 'org.codehaus.groovy', name: 'groovy-json', version: '2.5.14'
 
     integrationTestCompile(group: 'org.yaml', name: 'snakeyaml', version: '1.23') {
         force = true

--- a/build.gradle
+++ b/build.gradle
@@ -264,6 +264,21 @@ dependencies {
         because 'Apache HttpClient versions prior to version 4.5.13 can misinterpret malformed authority component in ' +
                 'request URIs passed to the library as java.net.URI object and pick the wrong target host for request execution.'
     }
+    implementation('org.codehaus.groovy:groovy:2.5.14') {
+        because 'Apache Groovy provides extension methods to aid with creating temporary directories. ' +
+                'Prior to this fix, Groovy\'s implementation of those extension methods was using a now superseded ' +
+                'Java JDK method call that is potentially not secure on some operating systems in some contexts'
+    }
+    implementation('org.codehaus.groovy:groovy-json:2.5.14') {
+        because 'Apache Groovy provides extension methods to aid with creating temporary directories. ' +
+                'Prior to this fix, Groovy\'s implementation of those extension methods was using a now superseded ' +
+                'Java JDK method call that is potentially not secure on some operating systems in some contexts.'
+    }
+    implementation('org.codehaus.groovy:groovy-xml:2.5.14') {
+        because 'Apache Groovy provides extension methods to aid with creating temporary directories. ' +
+                'Prior to this fix, Groovy\'s implementation of those extension methods was using a now superseded ' +
+                'Java JDK method call that is potentially not secure on some operating systems in some contexts.'
+    }
 
     testCompile group: 'io.rest-assured', name: 'rest-assured', version: '3.3.0'
 
@@ -310,6 +325,10 @@ dependencies {
     testCompile(group: 'org.yaml', name: 'snakeyaml', version: '1.25') {
         force = true
     }
+
+    testCompile group: 'org.codehaus.groovy', name: 'groovy', version: '2.5.14'
+    testCompile group: 'org.codehaus.groovy', name: 'groovy-xml', version: '2.5.14'
+    testCompile group: 'org.codehaus.groovy', name: 'groovy-json', version: '2.5.14'
 
     integrationTestCompile(group: 'org.yaml', name: 'snakeyaml', version: '1.23') {
         force = true


### PR DESCRIPTION
### JIRA link  ###

https://tools.hmcts.net/jira/browse/RDCC-2107

### Change description ###
Fixed CVE-2020-17527 and CVE-2020-13956 by upgrading

tomcat-embed-core
tomcat-embed-websocket
httpclient


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
