### PR TITLE
fix: RDCC-2507 Upgraded spring boot version to fix CVE CVE-2021-22112

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ plugins {
     id "info.solidsoft.pitest" version '1.5.1'
     id 'io.spring.dependency-management' version '1.0.9.RELEASE'
     id 'org.sonarqube' version '2.8'
-    id 'org.springframework.boot' version '2.3.4.RELEASE'
+    id 'org.springframework.boot' version '2.3.9.RELEASE'
     id "org.flywaydb.flyway" version "6.5.1"
     id "io.freefair.lombok" version "4.1.6"
     id 'uk.gov.hmcts.java' version '0.12.0'
@@ -32,7 +32,7 @@ def versions = [
         reformS2sClient    : '3.1.2',
         serenity           : '2.0.76',
         sonarPitest        : '0.5',
-        springBoot         : '2.3.4.RELEASE',
+        springBoot         : '2.3.9.RELEASE',
         springHystrix      : '2.1.1.RELEASE',
         springfoxSwagger   : '2.9.2'
 ]


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDCC-2507

### Change description ###
Upgraded spring boot version to fix CVE CVE-2021-22112

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
