### PR TITLE
Bugfix: JRD : Ticket code is not populated for some records in judicial_office_authorisation table

### DIFF
--- a/src/main/resources/db/migration/V1_28__update_ticket_code_mapping.sql
+++ b/src/main/resources/db/migration/V1_28__update_ticket_code_mapping.sql
@@ -1,0 +1,9 @@
+UPDATE judicial_ticket_code_mapping SET lower_level = 'Section 9(1) Chancery' WHERE ticket_code = '300';
+UPDATE judicial_ticket_code_mapping SET lower_level = 'Section 9(1) Queens Bench' WHERE ticket_code = '301';
+UPDATE judicial_ticket_code_mapping SET lower_level = 'Section 9(1) Queens Bench - Admin ONLY' WHERE ticket_code = '393';
+UPDATE judicial_ticket_code_mapping SET lower_level = 'Section 9(1) IPEC' WHERE ticket_code = '396';
+UPDATE judicial_ticket_code_mapping SET lower_level = 'S9(4) Appointment - Chancery' WHERE ticket_code = '397';
+UPDATE judicial_ticket_code_mapping SET lower_level = 'S9(4) Appointment - Queens Bench' WHERE ticket_code = '398';
+UPDATE judicial_ticket_code_mapping SET lower_level = 'S9(4) Appointment - Family' WHERE ticket_code = '400';
+
+COMMIT;


### PR DESCRIPTION
Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDCC-3505

### Change description ###

JRD : Ticket code is not populated for some records in judicial_office_authorisation table

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
