### PR TITLE
fix: CVE-2021-22096 by upgrading springboot version to 2.4.12

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ plugins {
     id "info.solidsoft.pitest" version '1.5.2'
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
     id 'org.sonarqube' version '3.1.1'
-    id 'org.springframework.boot' version '2.4.9'
+    id 'org.springframework.boot' version '2.4.12'
     id "org.flywaydb.flyway" version "6.5.1"
     id "io.freefair.lombok" version "4.1.6"
     id 'uk.gov.hmcts.java' version '0.12.0'

--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ def versions = [
         reformS2sClient    : '4.0.0',
         serenity           : '2.0.76',
         sonarPitest        : '0.5',
-        springBoot         : '2.4.9',
+        springBoot         : '2.4.12',
         springHystrix      : '2.1.1.RELEASE',
         springfoxSwagger   : '2.9.2',
         restAssured        : '4.3.3',


### PR DESCRIPTION
### Change description ###

CVE-2021-22096 by upgrading springboot version to 2.4.12

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
