### PR TITLE
feat: RDCC-3760 Returned 200 empty array instead of 404 when no data found for search string

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/judicialapi/controller/JrdUsersController.java
+++ b/src/main/java/uk/gov/hmcts/reform/judicialapi/controller/JrdUsersController.java
@@ -127,11 +127,7 @@ public class JrdUsersController {
             @ApiResponse(
                     code = 403,
                     message = "Unauthorized"
-            ),
-            @ApiResponse(
-                    code = 404,
-                    message = "No Users Found"
-            ),
+            )
             @ApiResponse(
                     code = 500,
                     message = "Internal Server Error"

--- a/src/main/java/uk/gov/hmcts/reform/judicialapi/controller/JrdUsersController.java
+++ b/src/main/java/uk/gov/hmcts/reform/judicialapi/controller/JrdUsersController.java
@@ -127,7 +127,7 @@ public class JrdUsersController {
             @ApiResponse(
                     code = 403,
                     message = "Unauthorized"
-            )
+            ),
             @ApiResponse(
                     code = 500,
                     message = "Internal Server Error"

--- a/src/main/java/uk/gov/hmcts/reform/judicialapi/service/impl/JudicialUserServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/judicialapi/service/impl/JudicialUserServiceImpl.java
@@ -47,7 +47,6 @@ import java.util.stream.Collectors;
 import java.util.Set;
 
 import static java.util.Objects.nonNull;
-import static uk.gov.hmcts.reform.judicialapi.util.JrdConstant.USER_DATA_NOT_FOUND;
 import static uk.gov.hmcts.reform.judicialapi.util.RefDataUtil.createPageableObject;
 
 @Slf4j
@@ -117,10 +116,6 @@ public class JudicialUserServiceImpl implements JudicialUserService {
         var userProfiles = userProfileRepository
                 .findBySearchString(userSearchRequest.getSearchString().toLowerCase(),
                         userSearchRequest.getServiceCode(), userSearchRequest.getLocation(), ticketCode);
-
-        if (CollectionUtils.isEmpty(userProfiles)) {
-            throw new ResourceNotFoundException(USER_DATA_NOT_FOUND);
-        }
 
         var userSearchResponses = userProfiles
                 .stream()

--- a/src/test/java/uk/gov/hmcts/reform/judicialapi/controller/service/impl/JudicialUserServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/judicialapi/controller/service/impl/JudicialUserServiceImplTest.java
@@ -153,7 +153,7 @@ class JudicialUserServiceImplTest {
     }
 
     @Test
-    void shouldReturn404WhenUserNotFoundForTheSearchRequestProvided() {
+    void shouldReturn200WithEmptyResponseWhenUserNotFoundForTheSearchRequestProvided() {
 
         var userSearchRequest = UserSearchRequest
                 .builder()
@@ -164,8 +164,12 @@ class JudicialUserServiceImplTest {
         when(userProfileRepository.findBySearchString(any(), any(), any(), any()))
                 .thenReturn(Collections.emptyList());
 
-        Assertions.assertThrows(ResourceNotFoundException.class, () ->
-                judicialUserService.retrieveUserProfile(userSearchRequest));
+        var responseEntity =
+                judicialUserService.retrieveUserProfile(userSearchRequest);
+        assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
+        assertEquals(Collections.EMPTY_LIST, responseEntity.getBody());
+        verify(userProfileRepository, times(1)).findBySearchString(any(),any(),
+                any(), anyList());
     }
 
     @Test


### PR DESCRIPTION
### JIRA link ###

https://tools.hmcts.net/jira/browse/RDCC-3760

### Change description ###
Returned 200 empty array instead of 404 when no data found for search string


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
