### PR TITLE
 fix: patch log4j to the 2.16.0 in all applications to fix CVE-2021-45046

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ def versions = [
         jackson            : '2.12.1',
         launchDarklySdk    : '5.2.2',
         pact_version       : '4.1.7',
-        log4j              : '2.15.0'
+        log4j              : '2.16.0'
 ]
 
 mainClassName = 'uk.gov.hmcts.reform.judicialapi.JudicialApplication'


### PR DESCRIPTION
### JIRA link ###

https://tools.hmcts.net/jira/browse/RDCC-3799

### Change description ###

patch log4j to the 2.16.0 in all applications to fix CVE-2021-45046

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```