### PR TITLE
RDCC-3842: Adding Validation for Request Body in Refresh API

### DIFF
--- a/src/contractTest/java/uk/gov/hmcts/reform/judicialapi/provider/JrdApiProviderTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/reform/judicialapi/provider/JrdApiProviderTest.java
@@ -132,7 +132,7 @@ public class JrdApiProviderTest {
     @State({"return judicial user profiles along with their active appointments and authorisations"})
     public void toReturnUserProfilesDetailsForRefreshUserProfile() throws JsonProcessingException {
 
-        doNothing().when(refreshUserValidator).shouldContainOnlyOneInputParameter(any());
+        doNothing().when(refreshUserValidator).shouldContainOnlyOneNotEmptyInputParameter(any());
         when(refreshUserValidator.isStringNotEmptyOrNotNull(any())).thenReturn(Boolean.TRUE);
         when(refreshUserValidator.isListNotEmptyOrNotNull(any())).thenReturn(Boolean.FALSE);
 

--- a/src/main/java/uk/gov/hmcts/reform/judicialapi/service/impl/JudicialUserServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/judicialapi/service/impl/JudicialUserServiceImpl.java
@@ -133,7 +133,7 @@ public class JudicialUserServiceImpl implements JudicialUserService {
     public ResponseEntity<Object> refreshUserProfile(RefreshRoleRequest refreshRoleRequest, Integer pageSize,
                                                      Integer pageNumber, String sortDirection, String sortColumn) {
 
-        refreshUserValidator.shouldContainOnlyOneInputParameter(refreshRoleRequest);
+        refreshUserValidator.shouldContainOnlyOneNotEmptyInputParameter(refreshRoleRequest);
         var pageRequest = RequestUtils.validateAndBuildPaginationObject(pageSize, pageNumber,
                 sortDirection, sortColumn, refreshDefaultPageSize, refreshDefaultSortColumn,
                 UserProfile.class);

--- a/src/main/java/uk/gov/hmcts/reform/judicialapi/validator/RefreshUserValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/judicialapi/validator/RefreshUserValidator.java
@@ -17,15 +17,21 @@ import static uk.gov.hmcts.reform.judicialapi.util.RefDataConstants.ONLY_ONE_PAR
 @NoArgsConstructor
 public class RefreshUserValidator {
 
-    public void shouldContainOnlyOneInputParameter(RefreshRoleRequest refreshRoleRequest) {
+    public void shouldContainOnlyOneNotEmptyInputParameter(RefreshRoleRequest refreshRoleRequest) {
         if (null != refreshRoleRequest) {
             boolean ccdServiceNames = isStringNotEmptyOrNotNull(refreshRoleRequest.getCcdServiceNames());
             boolean objectIds = isListNotEmptyOrNotNull(refreshRoleRequest.getObjectIds());
             boolean sidamIds = isListNotEmptyOrNotNull(refreshRoleRequest.getSidamIds());
 
+            if (!ccdServiceNames && !objectIds && !sidamIds) {
+                throw new InvalidRequestException("Request Body cannot be empty");
+            }
+
             if (ccdServiceNames ? (objectIds || sidamIds) : (objectIds && sidamIds)) {
                 throw new InvalidRequestException(ONLY_ONE_PARAMETER_REQUIRED);
             }
+        } else {
+            throw new InvalidRequestException("Request Body cannot be Null");
         }
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/judicialapi/controller/service/impl/JudicialUserServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/judicialapi/controller/service/impl/JudicialUserServiceImplTest.java
@@ -55,6 +55,7 @@ import static org.hamcrest.junit.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.times;
@@ -364,20 +365,16 @@ class JudicialUserServiceImplTest {
     }
 
     @Test
-    public void test_refreshUserProfile_BasedOn_All_200() throws JsonProcessingException {
+    public void test_refreshUserProfile_BasedOn_All_400() throws JsonProcessingException {
         var userProfile = buildUserProfile();
 
         var pageRequest = getPageRequest();
         var page = new PageImpl<>(Collections.singletonList(userProfile));
-        when(userProfileRepository.fetchUserProfileByAll(pageRequest))
-                .thenReturn(page);
         var refreshRoleRequest = new RefreshRoleRequest("",  null, null);
-        var responseEntity = judicialUserService.refreshUserProfile(refreshRoleRequest, 1,
-                0, "ASC", "objectId");
-
-        assertEquals(200, responseEntity.getStatusCodeValue());
-        UserProfileRefreshResponse profile = (UserProfileRefreshResponse) ((List<?>) responseEntity.getBody()).get(0);
-        assertThat(profile.getAppointments().get(0).getRoles(), containsInAnyOrder("Test1","Test3"));
+        Assertions.assertThrows(InvalidRequestException.class, () -> {
+            judicialUserService.refreshUserProfile(refreshRoleRequest, 1,
+                    0, "ASC", "objectId");
+        });
     }
 
     @NotNull


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDCC-3842

### Change description ###

Adding Validation on empty/null checks for Request Body in Refresh API

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
