### PR TITLE
RDCC-5261: Upgrading postgresql to version 42.4.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -329,7 +329,7 @@ dependencies {
     implementation 'com.github.hmcts:service-auth-provider-java-client:4.0.3'
 
     implementation group: 'org.flywaydb', name: 'flyway-core', version: '7.10.0'
-    implementation group: 'org.postgresql', name: 'postgresql', version: '42.3.3'
+    implementation group: 'org.postgresql', name: 'postgresql', version: '42.4.1'
     implementation group: 'com.launchdarkly', name: 'launchdarkly-java-server-sdk', version: versions.launchDarklySdk
     implementation group: 'commons-lang', name: 'commons-lang', version: '2.6'
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.10'


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RDCC-5261


### Change description ###
Upgrading postgresql to version 42.4.1 to fix CVE-2022-31197


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
