### PR TITLE
RDCC-5534: Upgrading `launchdarkly-java-server-sdk` & `snakeyaml`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -417,23 +417,7 @@ dependencies {
     testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: versions.springBoot
 
 
-    testImplementation(group: 'org.yaml', name: 'snakeyaml') {
-        version {
-            strictly '1.33'
-        }
-    }
-
-    integrationTestImplementation(group: 'org.yaml', name: 'snakeyaml') {
-        version {
-            strictly '1.33'
-        }
-    }
-
-    functionalTestImplementation(group: 'org.yaml', name: 'snakeyaml') {
-        version{
-            strictly '1.33'
-        }
-    }
+    implementation group: 'org.yaml', name: 'snakeyaml', version: '1.33'
 
     contractTestImplementation group: 'au.com.dius.pact.consumer', name: 'junit5', version: versions.pact_version
     contractTestImplementation group: 'au.com.dius.pact.consumer', name: 'junit5', version: versions.pact_version

--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ def versions = [
         springfoxSwagger   : '2.9.2',
         restAssured        : '4.3.3',
         jackson            : '2.13.2',
-        launchDarklySdk    : '5.8.1',
+        launchDarklySdk    : '5.10.2',
         pact_version       : '4.1.7',
         log4j              : '2.17.1',
         springVersion      : '5.3.20',
@@ -419,19 +419,19 @@ dependencies {
 
     testImplementation(group: 'org.yaml', name: 'snakeyaml') {
         version {
-            strictly '1.31'
+            strictly '1.33'
         }
     }
 
     integrationTestImplementation(group: 'org.yaml', name: 'snakeyaml') {
         version {
-            strictly '1.31'
+            strictly '1.33'
         }
     }
 
     functionalTestImplementation(group: 'org.yaml', name: 'snakeyaml') {
         version{
-            strictly '1.31'
+            strictly '1.33'
         }
     }
 

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -19,12 +19,4 @@
    ]]></notes>
         <cve>CVE-2022-34305</cve>
     </suppress>
-    <suppress>
-        <notes>Suppressed due to unavailability of updated version of launchdarkly-java-server-sdk</notes>
-        <packageUrl regex="true">^pkg:maven/org\.yaml/snakeyaml@.*$</packageUrl>
-        <cve>CVE-2022-25857</cve>
-        <cve>CVE-2022-38749</cve>
-        <cve>CVE-2022-38750</cve>
-        <cve>CVE-2022-38751</cve>
-    </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDCC-5534

### Change description ###

Upgrading `launchdarkly-java-server-sdk` & `snakeyaml` to fix CVE-2022-38752

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
