### PR TITLE
RDCC-6130: Adding suppressions for `CVE-2022-3064` & `CVE-2021-4235`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -371,8 +371,6 @@ dependencies {
     implementation "com.github.hmcts.java-logging:logging-appinsights:${versions.reformLogging}"
     
     
-    implementation group: 'com.thoughtworks.xstream', name: 'xstream', version: '1.4.20'
-
 
     testImplementation ('com.github.hmcts:rd-commons-lib:v0.0.13'){
         exclude group: 'org.springframework.boot', module: 'spring-boot-starter-web'

--- a/build.gradle
+++ b/build.gradle
@@ -369,6 +369,9 @@ dependencies {
     implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: versions.log4j
     implementation "com.github.hmcts.java-logging:logging:${versions.reformLogging}"
     implementation "com.github.hmcts.java-logging:logging-appinsights:${versions.reformLogging}"
+    
+    
+    implementation group: 'com.thoughtworks.xstream', name: 'xstream', version: '1.4.20'
 
 
     testImplementation ('com.github.hmcts:rd-commons-lib:v0.0.13'){

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -24,4 +24,10 @@
     <notes>cucumber:datatable pom contains com.googlecode.java-diff-utils:diffutils which has the CVE vulnerability, no fix has been released yet for this</notes>
     <cve>CVE-2021-4277</cve>
   </suppress>
+    </suppress>
+      <suppress>
+        <packageUrl regex="true">^pkg:maven/org\.yaml/snakeyaml@.*$</packageUrl>
+        <cve>CVE-2021-4235</cve>
+        <cve>CVE-2022-3064</cve>
+    </suppress>
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -24,7 +24,6 @@
     <notes>cucumber:datatable pom contains com.googlecode.java-diff-utils:diffutils which has the CVE vulnerability, no fix has been released yet for this</notes>
     <cve>CVE-2021-4277</cve>
   </suppress>
-    </suppress>
       <suppress>
         <packageUrl regex="true">^pkg:maven/org\.yaml/snakeyaml@.*$</packageUrl>
         <cve>CVE-2021-4235</cve>


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDCC-6130

### Change description ###

Adding suppressions for `CVE-2022-3064` & `CVE-2021-4235`

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
