### PR TITLE
Nightly build failure

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ def versions = [
         launchDarklySdk    : '5.10.7',
         pact_version       : '4.1.7',
         log4j              : '2.18.0',
-        springVersion      : '5.3.20',
+        springVersion      : '5.3.26',
         logback            : '1.2.11',
         bytebuddy          : '1.12.7',
         testContainer_postgresql: '1.17.6'


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDCC-6656

### Change description ###

Addresses CVE-2023-20861

Remedied in spring 5.3.26 - https://spring.io/security/cve-2023-20861

CVE found in https://static-build.platform.hmcts.net/static-files/AycXpYDOj2jtJyL1qWOCazF_xCYGsT-l3T2G1TvDcNYxNjgwMTAwNzUyNzg2OjI0Okx1a2Fzei5Xb2xza2kxQEhNQ1RTLk5FVDp2aWV3L1JEL2pvYi9ITUNUU19qX3RvX3ovam9iL3JkLWp1ZGljaWFsLWFwaS9qb2IvbWFzdGVyLzg1L2FydGlmYWN0/build/reports/dependency-check-report.html

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
