### PR TITLE
Addresses CVE-2023-20863

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ def versions = [
         launchDarklySdk    : '5.10.7',
         pact_version       : '4.1.7',
         log4j              : '2.18.0',
-        springVersion      : '5.3.26',
+        springVersion      : '5.3.27',
         logback            : '1.2.11',
         bytebuddy          : '1.12.7',
         testContainer_postgresql: '1.17.6'


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSRD-264

### Change description ###

Addresses nightly build failure due to CVE-2023-20863

Mitigated in spring 5.3.27
https://spring.io/security/cve-2023-20863


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
