### PR TITLE
not to populate service codes in refresh api when service codes are e…

### DIFF
--- a/src/contractTest/java/uk/gov/hmcts/reform/judicialapi/provider/JrdApiProviderV2Test.java
+++ b/src/contractTest/java/uk/gov/hmcts/reform/judicialapi/provider/JrdApiProviderV2Test.java
@@ -49,6 +49,7 @@ import uk.gov.hmcts.reform.judicialapi.feign.LocationReferenceDataFeignClient;
 import java.nio.charset.Charset;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -285,8 +286,8 @@ public class JrdApiProviderV2Test {
         judicialRoleType.setRoleId(1L);
         judicialRoleType.setPersonalCode("testPersonalCode");
         judicialRoleType.setTitle("testTitle");
-        judicialRoleType.setStartDate(LocalDateTime.now());
-        judicialRoleType.setEndDate(LocalDateTime.now());
+        judicialRoleType.setStartDate(LocalDateTime.now().truncatedTo(ChronoUnit.SECONDS));
+        judicialRoleType.setEndDate(LocalDateTime.now().truncatedTo(ChronoUnit.SECONDS));
         judicialRoleType.setJurisdictionRoleId("testJurisdictionRoleId");
         userProfile.setJudicialRoleTypes(Collections.singletonList(judicialRoleType));
 

--- a/src/main/java/uk/gov/hmcts/reform/judicialapi/elinks/service/impl/ElinkUserServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/judicialapi/elinks/service/impl/ElinkUserServiceImpl.java
@@ -430,7 +430,7 @@ public class ElinkUserServiceImpl implements ElinkUserService {
 
         List<String> serviceCode = serviceCodeMappings.stream()
                 .filter(s -> s.getTicketCode().equalsIgnoreCase(auth.getTicketCode())
-                        && StringUtils.isNotEmpty(s.getServiceCode()))
+                        && StringUtils.isNotBlank(s.getServiceCode()))
                 .map(ServiceCodeMapping::getServiceCode).distinct()
                 .toList();
 

--- a/src/main/java/uk/gov/hmcts/reform/judicialapi/elinks/service/impl/ElinkUserServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/judicialapi/elinks/service/impl/ElinkUserServiceImpl.java
@@ -429,7 +429,8 @@ public class ElinkUserServiceImpl implements ElinkUserService {
         log.info("{} : starting build Authorisation Refresh Response Dto ", loggingComponentName);
 
         List<String> serviceCode = serviceCodeMappings.stream()
-                .filter(s -> s.getTicketCode().equalsIgnoreCase(auth.getTicketCode()))
+                .filter(s -> s.getTicketCode().equalsIgnoreCase(auth.getTicketCode())
+                        && StringUtils.isNotEmpty(s.getServiceCode()))
                 .map(ServiceCodeMapping::getServiceCode).distinct()
                 .toList();
 


### PR DESCRIPTION
Not populate service code when service codes are empty

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
