### PR TITLE
DTSRD-1456

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -530,6 +530,29 @@ dependencyManagement {
         dependencySet(group: 'com.fasterxml.woodstox', version: '6.5.0') {
             entry 'woodstox-core'
         }
+
+        //        Resolves CVE-2023-4586
+        dependencySet(group: 'io.netty', version: '4.1.100.Final') {
+            entry 'netty-buffer'
+            entry 'netty-codec'
+            entry 'netty-codec-dns'
+            entry 'netty-codec-http'
+            entry 'netty-codec-http2'
+            entry 'netty-codec-socks'
+            entry 'netty-common'
+            entry 'netty-handler'
+            entry 'netty-handler-proxy'
+            entry 'netty-resolver'
+            entry 'netty-resolver-dns'
+            entry 'netty-resolver-dns-classes-macos'
+            entry 'netty-resolver-dns-native-macos'
+            entry 'netty-transport'
+            entry 'netty-transport-classes-epoll'
+            entry 'netty-transport-classes-kqueue'
+            entry 'netty-transport-native-epoll'
+            entry 'netty-transport-native-kqueue'
+            entry 'netty-transport-native-unix-common'
+        }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -530,28 +530,13 @@ dependencyManagement {
         dependencySet(group: 'com.fasterxml.woodstox', version: '6.5.0') {
             entry 'woodstox-core'
         }
-
-        //        Resolves CVE-2023-4586
-        dependencySet(group: 'io.netty', version: '4.1.100.Final') {
-            entry 'netty-buffer'
-            entry 'netty-codec'
-            entry 'netty-codec-dns'
-            entry 'netty-codec-http'
-            entry 'netty-codec-http2'
-            entry 'netty-codec-socks'
-            entry 'netty-common'
-            entry 'netty-handler'
-            entry 'netty-handler-proxy'
-            entry 'netty-resolver'
-            entry 'netty-resolver-dns'
-            entry 'netty-resolver-dns-classes-macos'
-            entry 'netty-resolver-dns-native-macos'
-            entry 'netty-transport'
-            entry 'netty-transport-classes-epoll'
-            entry 'netty-transport-classes-kqueue'
-            entry 'netty-transport-native-epoll'
-            entry 'netty-transport-native-kqueue'
-            entry 'netty-transport-native-unix-common'
+    }
+}
+configurations.all {
+    resolutionStrategy.eachDependency { details ->
+//        Resolves CVE-2023-4586
+        if (details.requested.group == 'io.netty') {
+            details.useVersion "4.1.100.Final"
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -530,13 +530,28 @@ dependencyManagement {
         dependencySet(group: 'com.fasterxml.woodstox', version: '6.5.0') {
             entry 'woodstox-core'
         }
-    }
-}
-configurations.all {
-    resolutionStrategy.eachDependency { details ->
-//        Resolves CVE-2023-4586
-        if (details.requested.group == 'io.netty') {
-            details.useVersion "4.1.100.Final"
+
+        //        Resolves CVE-2023-4586
+        dependencySet(group: 'io.netty', version: '4.1.100.Final') {
+            entry 'netty-buffer'
+            entry 'netty-codec'
+            entry 'netty-codec-dns'
+            entry 'netty-codec-http'
+            entry 'netty-codec-http2'
+            entry 'netty-codec-socks'
+            entry 'netty-common'
+            entry 'netty-handler'
+            entry 'netty-handler-proxy'
+            entry 'netty-resolver'
+            entry 'netty-resolver-dns'
+            entry 'netty-resolver-dns-classes-macos'
+            entry 'netty-resolver-dns-native-macos'
+            entry 'netty-transport'
+            entry 'netty-transport-classes-epoll'
+            entry 'netty-transport-classes-kqueue'
+            entry 'netty-transport-native-epoll'
+            entry 'netty-transport-native-kqueue'
+            entry 'netty-transport-native-unix-common'
         }
     }
 }

--- a/charts/rd-judicial-api/Chart.yaml
+++ b/charts/rd-judicial-api/Chart.yaml
@@ -2,12 +2,12 @@ apiVersion: v2
 appVersion: "0.1"
 description: Reference data service for judiciary
 name: rd-judicial-api
-version: 1.0.0
+version: 1.0.1
 maintainers:
   - name: Reference Data Team
 dependencies:
   - name: java
-    version: 4.0.13
+    version: 5.0.0
     repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
   - name: servicebus
     version: 1.0.4


### PR DESCRIPTION
- Updating Netty versions for CVE-2023-4586.
- Updating helm version; Version of java helm chart below 5.0.0 is deprecated, please upgrade to latest release https://github.com/hmcts/chart-java/releases This configuration will stop working by 23/10/2023

### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSRD-1456

### Change description ###

- Updating Netty versions for CVE-2023-4586.
- Updating helm version; Version of java helm chart below 5.0.0 is deprecated, please upgrade to latest release https://github.com/hmcts/chart-java/releases This configuration will stop working by 23/10/2023

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change
