### PR TITLE
DTSRD-3567 Elinks - Audit tables were not accessible in PROD 

### DIFF
--- a/src/main/resources/db/migration/V1_8__elinks_grant_access_dbjudicialdata_for_aduit_tables.sql
+++ b/src/main/resources/db/migration/V1_8__elinks_grant_access_dbjudicialdata_for_aduit_tables.sql
@@ -1,0 +1,3 @@
+-- Grant usage and select privileges on Reader user for the audit tables
+GRANT USAGE ON SCHEMA dbjudicialdata TO "${dbReaderUserName}";
+GRANT SELECT ON ALL TABLES IN SCHEMA dbjudicialdata TO "${dbReaderUserName}";


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DTSRD-3567

### Change description
Elinks - Audit tables were not accessible in PROD - V1_8__elinks_grant_access_dbjudicialdata_for_aduit_tables.sql added for the audit tables

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] Does this PR introduce a breaking change
