### PR TITLE
DTSRD-3580 Jenkins Test Reports to Publish on Failure - afterSuccess(…

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -113,7 +113,7 @@ withPipeline(type, product, component) {
     // Sync demo and perftest with master branch
     syncBranchesWithMaster(branchesToSync)
 
-    afterSuccess('sonarscan') {
+    afterAlways('sonarscan') {
 
         publishHTML target: [
             allowMissing         : true,
@@ -134,7 +134,7 @@ withPipeline(type, product, component) {
         ]
     }
 
-    afterSuccess('smoketest:preview') {
+    afterAlways('smoketest:preview') {
         publishHTML target: [
             allowMissing         : true,
             alwaysLinkToLastBuild: true,
@@ -145,7 +145,7 @@ withPipeline(type, product, component) {
         ]
     }
 
-    afterSuccess('smoketest:aat') {
+    afterAlways('smoketest:aat') {
         publishHTML target: [
             allowMissing         : true,
             alwaysLinkToLastBuild: true,
@@ -156,7 +156,7 @@ withPipeline(type, product, component) {
         ]
     }
 
-    afterSuccess('functionalTest:aat') {
+    afterAlways('functionalTest:aat') {
         steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/site/serenity/**/*'
         publishHTML target: [
             allowMissing         : true,
@@ -168,7 +168,7 @@ withPipeline(type, product, component) {
         ]
     }
 
-    afterSuccess('functionalTest:preview') {
+    afterAlways('functionalTest:preview') {
         steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/site/serenity/**/*'
         publishHTML target: [
             allowMissing         : true,
@@ -180,7 +180,7 @@ withPipeline(type, product, component) {
         ]
     }
 
-    afterSuccess('pact-provider-verification') {
+    afterAlways('pact-provider-verification') {
         publishHTML target: [
              allowMissing         : true,
              alwaysLinkToLastBuild: true,

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -68,11 +68,11 @@ withNightlyPipeline(type, product, component) {
     enableSecurityScan()
     enableFortifyScan()
 
-    afterSuccess('fortify-scan') {
+    afterAlways('fortify-scan') {
       steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/Fortify Scan/**/*'
     }
 
-    afterSuccess('mutationTest') {
+    afterAlways('mutationTest') {
         publishHTML target: [
                 allowMissing         : true,
                 alwaysLinkToLastBuild: true,
@@ -83,7 +83,7 @@ withNightlyPipeline(type, product, component) {
         ]
     }
 
-    afterSuccess('fullFunctionalTest') {
+    afterAlways('fullFunctionalTest') {
         steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/site/serenity/**/*'
         steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'build/reports/**/*'
         publishHTML target: [


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DTSRD-3580

### Change description
Jenkins Test Reports to Publish on Failure - afterSuccess() replaced with afterAlways() for all reports in Jenkinsfile_CNP and nightly

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] Does this PR introduce a breaking change
